### PR TITLE
Update code for Swift 5.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+
+name: build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: macos-12
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - name: build
+      run: swift build -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,10 @@
-# Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
-## Build generated
-build/
-DerivedData/
-
-## Various settings
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-xcuserdata/
-
-## Other
-*.moved-aside
-*.xcuserstate
+### Swift ###
+.build/
 
 ## Obj-C/Swift specific
 *.hmap
+
+## App packaging
 *.ipa
 *.dSYM.zip
 *.dSYM
@@ -32,37 +14,47 @@ timeline.xctimeline
 playground.xcworkspace
 
 # Swift Package Manager
-#
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
-.build/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
 
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# Pods/
+### Xcode ###
+## User settings
+xcuserdata/
 
-# Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+## Xcode 8 and earlier
+*.xcscmblueprint
+*.xccheckout
 
-Carthage/Build
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
-# screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
 
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots
-fastlane/test_output
 
-# FTFF
-.DS_Store
+### Xcode ###
+## User settings
+xcuserdata/
+
+## Xcode 8 and earlier
+*.xcscmblueprint
+*.xccheckout
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.3
+
 // ISC License
 //
 // Copyright (c) 2016, Justin Pawela and contributors
@@ -16,7 +18,27 @@
 
 import PackageDescription
 
-
 let package = Package(
-    name: "Foundation-XAttr"
+    name: "Foundation-XAttr",
+    platforms: [
+        .iOS(.v14),
+        .macOS(.v10_13),
+        .watchOS(.v7),
+        .tvOS(.v14)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Foundation-XAttr",
+            targets: [
+                "Foundation-XAttr",
+            ]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "Foundation-XAttr",
+            path: "Sources/"
+        )
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Foundation-XAttr makes working with [Extended Attributes][wiki-xattr] a natural part of Foundation. Both `NSURL` and `NSFileHandle` objects gain the ability to read and write extended attributes using an API that fits right in with Cocoa. Add the power of metadata to your app!
 
-Works with iOS, macOS, and tvOS.
+Works with iOS, macOS, watchOS and tvOS.
 
 For more info on Darwin's extended attribute APIs – which underlie this module – see Apple's man pages for [listxattr][man-listxattr], [getxattr][man-getxattr], [setxattr][man-setxattr], and [removexattr][man-removexattr].
 
@@ -36,7 +36,7 @@ try myURL.removeExtendedAttributes(forNames: nil)
 
 ## Installation
 
-Requires Swift 2.2.
+Requires Swift 5.3.
 
 ### Swift Package Manager
 
@@ -50,7 +50,7 @@ import PackageDescription
 let package = Package(
     name: "YourProjectName",
     dependencies: [
-        .Package(url: "https://github.com/overbuilt/foundation-xattr.git", majorVersion: 1),
+        .package(url: "https://github.com/overbuilt/foundation-xattr.git", majorVersion: 1),
     ]
 )
 

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -512,9 +512,10 @@ extension NSError {
     /// - parameter userInfo: Any additional data to include with the error.
     ///
     /// - returns: An `NSError` object with the domain `NSPOSIXErrorDomain`.
-    fileprivate class func POSIX(errno errNo: errno_t, userInfo: [NSObject: AnyObject]? = nil) -> Self {
+    fileprivate class func POSIX(errno errNo: errno_t, userInfo: [String: Any]? = nil) -> Self {
         return self.init(domain: NSPOSIXErrorDomain, code: Int(errNo), userInfo: {
-            if userInfo?[NSLocalizedDescriptionKey] == nil, let description = String(UTF8String: strerror(errNo)) {
+            if userInfo?[NSLocalizedDescriptionKey] == nil {
+                let description = String(cString: strerror(errNo))
                 var mutableUserInfo = userInfo ?? [:]
                 mutableUserInfo[NSLocalizedDescriptionKey] = description
                 return mutableUserInfo

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -234,7 +234,7 @@ private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, Unsafe
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getxattr.2.html
-private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutablePointer<Void>, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
+private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutableRawPointer, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
     assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute getter only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
@@ -275,7 +275,7 @@ private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/setxattr.2.html
-private func setXAttr<T>(target: T, name: String, value: NSData, options: XAttrOptions, setFunc: (T, UnsafePointer<CChar>, UnsafePointer<Void>, size_t, CUnsignedInt, CInt) -> CInt) throws {
+private func setXAttr<T>(target: T, name: String, value: NSData, options: XAttrOptions, setFunc: (T, UnsafePointer<CChar>, UnsafeRawPointer, size_t, CUnsignedInt, CInt) -> CInt) throws {
     assert(options.isSubset(of: [.NoFollow, .CreateOnly, .ReplaceOnly]),
         "Extended attribute setter only supports the following XAttrOptions: .NoFollow, .CreateOnly, .ReplaceOnly")
 

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -188,7 +188,7 @@ extension ExtendedAttributeHandler {
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/listxattr.2.html
 private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, UnsafeMutablePointer<CChar>, size_t, CInt) -> ssize_t) throws -> [String] {
-    assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
+    assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute lister only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
     let size = listFunc(target, nil, 0, options.rawValue)               // Get the size of the attributes' names.
@@ -235,7 +235,7 @@ private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, Unsafe
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getxattr.2.html
 private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutablePointer<Void>, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
-    assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
+    assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute getter only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
     let size = getFunc(target, name, nil, 0, 0, options.rawValue)       // Get the size of the attribute's value.
@@ -276,7 +276,7 @@ private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/setxattr.2.html
 private func setXAttr<T>(target: T, name: String, value: NSData, options: XAttrOptions, setFunc: (T, UnsafePointer<CChar>, UnsafePointer<Void>, size_t, CUnsignedInt, CInt) -> CInt) throws {
-    assert(options.isSubsetOf([.NoFollow, .CreateOnly, .ReplaceOnly]),
+    assert(options.isSubset(of: [.NoFollow, .CreateOnly, .ReplaceOnly]),
         "Extended attribute setter only supports the following XAttrOptions: .NoFollow, .CreateOnly, .ReplaceOnly")
 
     guard setFunc(target, name, value.bytes, value.length, 0, options.rawValue) == 0 else {
@@ -304,7 +304,7 @@ private func setXAttr<T>(target: T, name: String, value: NSData, options: XAttrO
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/removexattr.2.html
 private func removeXAttr<T>(target: T, name: String, options: XAttrOptions, delFunc: (T, UnsafePointer<CChar>, CInt) -> CInt) throws {
-    assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
+    assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute remover only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
     guard delFunc(target, name, options.rawValue) == 0 else {

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -187,7 +187,7 @@ extension ExtendedAttributeHandler {
 ///           `NSCocoaErrorDomain` and error code `NSFileReadInapplicableStringEncodingError` is thrown.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/listxattr.2.html
-private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, UnsafeMutablePointer<CChar>, size_t, CInt) -> ssize_t) throws -> [String] {
+private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, UnsafeMutablePointer<CChar>?, size_t, CInt) -> ssize_t) throws -> [String] {
     assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute lister only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
@@ -234,7 +234,7 @@ private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, Unsafe
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getxattr.2.html
-private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutableRawPointer, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
+private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutableRawPointer?, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
     assert(options.isSubset(of: [.NoFollow, .ShowCompression]),
         "Extended attribute getter only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -65,11 +65,11 @@ public struct XAttrOptions: OptionSet {
 /// - requires: `removeExtendedAttribute(forName:options:)`
 public protocol ExtendedAttributeHandler {
     /// Retrieve a list of extended attribute names associated with a file system object.
-    func extendedAttributeNames(options options: XAttrOptions) throws -> [String]
+    func extendedAttributeNames(options: XAttrOptions) throws -> [String]
     /// Retrieve the value for the extended attribute specified by _name_ associated with a file system object.
     func extendedAttributeValue(forName name: String, options: XAttrOptions) throws -> NSData
     /// Set a _name_:_value_ extended attribute on a file system object.
-    func setExtendedAttribute(name name: String, value: NSData, options: XAttrOptions) throws
+    func setExtendedAttribute(name: String, value: NSData, options: XAttrOptions) throws
     /// Remove the extended attribute specified by _name_ associated with a file system object.
     func removeExtendedAttribute(forName name: String, options: XAttrOptions) throws
     /// Retrieve the values for multiple extended attributes. A default implementation of this method is provided.
@@ -187,7 +187,7 @@ extension ExtendedAttributeHandler {
 ///           `NSCocoaErrorDomain` and error code `NSFileReadInapplicableStringEncodingError` is thrown.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/listxattr.2.html
-private func listXAttr<T>(target target: T, options: XAttrOptions, listFunc: (T, UnsafeMutablePointer<CChar>, size_t, CInt) -> ssize_t) throws -> [String] {
+private func listXAttr<T>(target: T, options: XAttrOptions, listFunc: (T, UnsafeMutablePointer<CChar>, size_t, CInt) -> ssize_t) throws -> [String] {
     assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
         "Extended attribute lister only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
@@ -234,7 +234,7 @@ private func listXAttr<T>(target target: T, options: XAttrOptions, listFunc: (T,
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getxattr.2.html
-private func getXAttr<T>(target target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutablePointer<Void>, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
+private func getXAttr<T>(target: T, name: String, options: XAttrOptions, getFunc: (T, UnsafePointer<CChar>, UnsafeMutablePointer<Void>, size_t, CUnsignedInt, CInt) -> ssize_t) throws -> NSData {
     assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
         "Extended attribute getter only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
@@ -275,7 +275,7 @@ private func getXAttr<T>(target target: T, name: String, options: XAttrOptions, 
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/setxattr.2.html
-private func setXAttr<T>(target target: T, name: String, value: NSData, options: XAttrOptions, setFunc: (T, UnsafePointer<CChar>, UnsafePointer<Void>, size_t, CUnsignedInt, CInt) -> CInt) throws {
+private func setXAttr<T>(target: T, name: String, value: NSData, options: XAttrOptions, setFunc: (T, UnsafePointer<CChar>, UnsafePointer<Void>, size_t, CUnsignedInt, CInt) -> CInt) throws {
     assert(options.isSubsetOf([.NoFollow, .CreateOnly, .ReplaceOnly]),
         "Extended attribute setter only supports the following XAttrOptions: .NoFollow, .CreateOnly, .ReplaceOnly")
 
@@ -303,7 +303,7 @@ private func setXAttr<T>(target target: T, name: String, value: NSData, options:
 ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
 ///
 /// [man]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/removexattr.2.html
-private func removeXAttr<T>(target target: T, name: String, options: XAttrOptions, delFunc: (T, UnsafePointer<CChar>, CInt) -> CInt) throws {
+private func removeXAttr<T>(target: T, name: String, options: XAttrOptions, delFunc: (T, UnsafePointer<CChar>, CInt) -> CInt) throws {
     assert(options.isSubsetOf([.NoFollow, .ShowCompression]),
         "Extended attribute remover only supports the following XAttrOptions: .NoFollow, .ShowCompression")
 
@@ -335,7 +335,7 @@ extension NSURL: ExtendedAttributeHandler {
     ///           and the _localizedDescription_ property for a description of the error. If the attribute names are
     ///           retrieved, but cannot be read due to bad encoding, an `NSError` with Foundation built-in domain
     ///           `NSCocoaErrorDomain` and error code `NSFileReadInapplicableStringEncodingError` is thrown.
-    public func extendedAttributeNames(options options: XAttrOptions = []) throws -> [String] {
+    public func extendedAttributeNames(options: XAttrOptions = []) throws -> [String] {
         assert(self.isFileURL, "Extended attributes are only available for file URLs")
         return try listXAttr(target: self.fileSystemRepresentation, options: options, listFunc: listxattr)
     }
@@ -373,7 +373,7 @@ extension NSURL: ExtendedAttributeHandler {
     ///
     /// - throws: `NSError` with Foundation built-in domain `NSPOSIXErrorDomain`. Check the _code_ property for the
     ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
-    public func setExtendedAttribute(name name: String, value: NSData, options: XAttrOptions = []) throws {
+    public func setExtendedAttribute(name: String, value: NSData, options: XAttrOptions = []) throws {
         assert(self.isFileURL, "Extended attributes are only available for file URLs")
         try setXAttr(target: self.fileSystemRepresentation, name: name, value: value, options: options, setFunc: setxattr)
     }
@@ -415,7 +415,7 @@ extension NSFileHandle: ExtendedAttributeHandler {
     ///           and the _localizedDescription_ property for a description of the error. If the attribute names are
     ///           retrieved, but cannot be read due to bad encoding, an `NSError` with Foundation built-in domain
     ///           `NSCocoaErrorDomain` and error code `NSFileReadInapplicableStringEncodingError` is thrown.
-    public func extendedAttributeNames(options options: XAttrOptions = []) throws -> [String] {
+    public func extendedAttributeNames(options: XAttrOptions = []) throws -> [String] {
         //TODO: Update this ugly assertion with better FileHandle code.
         assert({ var statbuf: stat = stat(); guard fstat(self.fileDescriptor, &statbuf) == 0 else { return false }
             return Set([S_IFDIR, S_IFREG, S_IFLNK]).contains(statbuf.st_mode & S_IFMT)
@@ -459,7 +459,7 @@ extension NSFileHandle: ExtendedAttributeHandler {
     ///
     /// - throws: `NSError` with Foundation built-in domain `NSPOSIXErrorDomain`. Check the _code_ property for the
     ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
-    public func setExtendedAttribute(name name: String, value: NSData, options: XAttrOptions = []) throws {
+    public func setExtendedAttribute(name: String, value: NSData, options: XAttrOptions = []) throws {
         //TODO: Update this ugly assertion with better FileHandle code.
         assert({ var statbuf: stat = stat(); guard fstat(self.fileDescriptor, &statbuf) == 0 else { return false }
             return Set([S_IFDIR, S_IFREG, S_IFLNK]).contains(statbuf.st_mode & S_IFMT)

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -203,10 +203,10 @@ private func listXAttr<T>(target target: T, options: XAttrOptions, listFunc: (T,
         throw NSError.POSIX(errno: errno)
     }
 
-    guard let list = String(data: data, encoding: NSUTF8StringEncoding) else {
+    guard let list = String(data: data, encoding: .utf8) else {
         throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadInapplicableStringEncodingError, userInfo: [
             NSLocalizedDescriptionKey: "Could not decode extended attribute names.",
-            NSStringEncodingErrorKey: NSNumber(unsignedInteger: NSUTF8StringEncoding),
+            NSStringEncodingErrorKey: NSNumber(value: NSUTF8StringEncoding),
         ])
     }
     return list.componentsSeparatedByString("\0").filter({ !$0.isEmpty })

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -33,7 +33,7 @@ public let ExtendedAttributeNameKey: String = "tech.overbuilt.userInfoKey.extend
 ///
 /// - important: Options `.CreateOnly` and `.ReplaceOnly` are mutually exclusive. However, neither option is required,
 ///              and supplying neither when setting an extended attribute allows for both creation and replacement.
-public struct XAttrOptions: OptionSetType {
+public struct XAttrOptions: OptionSet {
     public let rawValue: CInt
 
     public init(rawValue: CInt) { self.rawValue = rawValue }

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -336,7 +336,7 @@ extension NSURL: ExtendedAttributeHandler {
     ///           retrieved, but cannot be read due to bad encoding, an `NSError` with Foundation built-in domain
     ///           `NSCocoaErrorDomain` and error code `NSFileReadInapplicableStringEncodingError` is thrown.
     public func extendedAttributeNames(options options: XAttrOptions = []) throws -> [String] {
-        assert(self.fileURL, "Extended attributes are only available for file URLs")
+        assert(self.isFileURL, "Extended attributes are only available for file URLs")
         return try listXAttr(target: self.fileSystemRepresentation, options: options, listFunc: listxattr)
     }
 
@@ -355,7 +355,7 @@ extension NSURL: ExtendedAttributeHandler {
     /// - throws: `NSError` with Foundation built-in domain `NSPOSIXErrorDomain`. Check the _code_ property for the
     ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
     public func extendedAttributeValue(forName name: String, options: XAttrOptions = []) throws -> NSData {
-        assert(self.fileURL, "Extended attributes are only available for file URLs")
+        assert(self.isFileURL, "Extended attributes are only available for file URLs")
         return try getXAttr(target: self.fileSystemRepresentation, name: name, options: options, getFunc: getxattr)
     }
 
@@ -374,7 +374,7 @@ extension NSURL: ExtendedAttributeHandler {
     /// - throws: `NSError` with Foundation built-in domain `NSPOSIXErrorDomain`. Check the _code_ property for the
     ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
     public func setExtendedAttribute(name name: String, value: NSData, options: XAttrOptions = []) throws {
-        assert(self.fileURL, "Extended attributes are only available for file URLs")
+        assert(self.isFileURL, "Extended attributes are only available for file URLs")
         try setXAttr(target: self.fileSystemRepresentation, name: name, value: value, options: options, setFunc: setxattr)
     }
 
@@ -390,7 +390,7 @@ extension NSURL: ExtendedAttributeHandler {
     /// - throws: `NSError` with Foundation built-in domain `NSPOSIXErrorDomain`. Check the _code_ property for the
     ///           error's POSIX error code, and the _localizedDescription_ property for a description of the error.
     public func removeExtendedAttribute(forName name: String, options: XAttrOptions = []) throws {
-        assert(self.fileURL, "Extended attributes are only available for file URLs")
+        assert(self.isFileURL, "Extended attributes are only available for file URLs")
         try removeXAttr(target: self.fileSystemRepresentation, name: name, options: options, delFunc: removexattr)
     }
 

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -397,8 +397,8 @@ extension NSURL: ExtendedAttributeHandler {
 }
 
 
-/// Provides `NSFileHandle` with the ability to manipulate extended attributes associated with file descriptors.
-extension NSFileHandle: ExtendedAttributeHandler {
+/// Provides `FileHandle` with the ability to manipulate extended attributes associated with file descriptors.
+extension FileHandle: ExtendedAttributeHandler {
 
     /// Retrieves the extended attribute names associated with this file.
     ///

--- a/Sources/Foundation-XAttr.swift
+++ b/Sources/Foundation-XAttr.swift
@@ -508,7 +508,7 @@ extension NSError {
     /// - parameter userInfo: Any additional data to include with the error.
     ///
     /// - returns: An `NSError` object with the domain `NSPOSIXErrorDomain`.
-    private class func POSIX(errno errNo: errno_t, userInfo: [NSObject: AnyObject]? = nil) -> Self {
+    fileprivate class func POSIX(errno errNo: errno_t, userInfo: [NSObject: AnyObject]? = nil) -> Self {
         return self.init(domain: NSPOSIXErrorDomain, code: Int(errNo), userInfo: {
             if userInfo?[NSLocalizedDescriptionKey] == nil, let description = String(UTF8String: strerror(errNo)) {
                 var mutableUserInfo = userInfo ?? [:]
@@ -523,7 +523,7 @@ extension NSError {
     /// The system _errno_ as captured when the `NSError` object was created.
     ///
     /// - important: This attribute is only available for errors with the domain `NSPOSIXErrorDomain`.
-    private var errno: errno_t {
+    fileprivate var errno: errno_t {
         assert(self.domain == NSPOSIXErrorDomain, "errno is only available for POSIX errors")
         return errno_t(self.code)
     }


### PR DESCRIPTION
Updated code to work with Xcode 12.4 and Swift 5.3 on macOS 10.15 or newer.

Fixes #1